### PR TITLE
Add multithreaded whatshap haplotag output compression

### DIFF
--- a/cluster.yaml
+++ b/cluster.yaml
@@ -20,6 +20,8 @@ deepvariant_postprocess_variants:
   extra: '--constraint=avx512'
 deepvariant_bcftools_stats:
   cpus: 4
+whatshap_haplotag:
+  cpus: 4
 samtools_index_bam_haplotag:
   cpus: 4
 merge_haplotagged_bams:

--- a/rules/envs/whatshap.yaml
+++ b/rules/envs/whatshap.yaml
@@ -3,5 +3,5 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - whatshap=1.1
+  - whatshap=1.4
   - python=3

--- a/rules/whatshap.smk
+++ b/rules/whatshap.smk
@@ -66,6 +66,7 @@ rule whatshap_haplotag:
         f"samples/{sample}/logs/whatshap/haplotag/{sample}.{ref}.{{movie}}.log",
     params:
         "--tag-supplementary",
+    threads: 4
     conda:
         "envs/whatshap.yaml"
     message:
@@ -73,6 +74,7 @@ rule whatshap_haplotag:
     shell:
         """
         (whatshap haplotag {params} \
+            --output-threads {threads} \
             --output {output} \
             --reference {input.reference} \
             {input.vcf} {input.bam}) > {log} 2>&1


### PR DESCRIPTION
In whatshap v1.3, an option was introduced to `haplotag` to allow additional threads for output compression ([link](https://github.com/whatshap/whatshap/pull/352#issue-1120974300)).  This PR updates to the most recent whatshap and provides 4 threads for `haplotag`.